### PR TITLE
Allow icons to be an arbitrary opacity

### DIFF
--- a/Material Kit Module/material-kit-icon.coffee
+++ b/Material Kit Module/material-kit-icon.coffee
@@ -7,6 +7,7 @@ exports.defaults = {
   superLayer: undefined
   constraints: undefined
   clip:true
+  opacity: 1
 }
 
 exports.defaults.props = Object.keys(exports.defaults)
@@ -21,6 +22,7 @@ exports.create = (array) ->
       clip:setup.clip
       name:setup.name
       superLayer:setup.superLayer
+      opacity:setup.opacity
 
     paddingRight = 0
     paddingTop = 0


### PR DESCRIPTION
Default value of 1. Example use: bottom navigation bars where the icons transition from a partial opacity to 1.